### PR TITLE
Scale blendshapes

### DIFF
--- a/PicoStreamingAssistantFTTests/FileBlendshapeScalerShould.cs
+++ b/PicoStreamingAssistantFTTests/FileBlendshapeScalerShould.cs
@@ -1,0 +1,146 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Pico4SAFTExtTrackingModule.PicoConnectors;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO.Abstractions.TestingHelpers;
+using System.Text;
+using VRCFaceTracking.Core.Params.Expressions;
+
+namespace Pico4SAFTExtTrackingModule.BlendshapeScaler;
+
+[TestClass]
+public class FileBlendshapeScalerShould
+{
+    private static FileBlendshapeScaler GetScaler()
+    {
+        return GetScaler(null);
+    }
+
+    private static FileBlendshapeScaler GetScaler(List<string>? errors)
+    {
+        return GetScalerWithCustomScales(new Dictionary<EyeExpressions, float>(), new Dictionary<UnifiedExpressions, float>(), errors); // no modifiers
+    }
+
+    private static FileBlendshapeScaler GetScalerWithCustomScales(Dictionary<EyeExpressions, float> eyeScales, Dictionary<UnifiedExpressions, float> unifiedScales)
+    {
+        return GetScalerWithCustomScales(eyeScales, unifiedScales, null);
+    }
+
+    private static string GetJsonContents(Dictionary<EyeExpressions, float> eyeScales, Dictionary<UnifiedExpressions, float> unifiedScales)
+    {
+        StringBuilder sb = new StringBuilder();
+        NumberFormatInfo nfi = new System.Globalization.NumberFormatInfo();
+        nfi.NumberDecimalSeparator = ".";
+
+        foreach (KeyValuePair<EyeExpressions, float> scale in eyeScales)
+        {
+            sb.Append("\"")
+                .Append(scale.Key.ToString())
+                .Append("\":")
+                .Append(scale.Value.ToString(nfi))
+                .Append(',');
+        }
+        
+        foreach (KeyValuePair<UnifiedExpressions, float> scale in unifiedScales)
+        {
+            sb.Append("\"")
+                .Append(scale.Key.ToString())
+                .Append("\":")
+                .Append(scale.Value.ToString(nfi))
+                .Append(',');
+        }
+
+        if (sb.Length > 0)
+        {
+            // not empty; we have to remove the last ','
+            sb.Length = sb.Length-1;
+        }
+
+        return "{\"scales\": {" + sb.ToString() + "}}";
+    }
+
+    private static FileBlendshapeScaler GetScalerWithCustomScales(Dictionary<EyeExpressions,float> eyeScales, Dictionary<UnifiedExpressions, float> unifiedScales, List<string>? errors)
+    {
+        MockFileSystem mockFileSysteme = new MockFileSystem();
+        string filePath = "ModuleConfig.json";
+        MockFileData mockFileData = new MockFileData(GetJsonContents(eyeScales, unifiedScales));
+        mockFileSysteme.AddFile(filePath, mockFileData);
+        Mock<ILogger> logger = (errors == null) ? new Mock<ILogger>() : PicoConnectConfigCheckerShould.GetLoggerMock(errors);
+
+        return new FileBlendshapeScaler(logger.Object, mockFileSysteme, filePath);
+    }
+
+    [TestMethod]
+    public void ReturnExpectedUsedShapes()
+    {
+        int numberOfEyeParamsSet = 6,
+            numberOfFaceParamsSet = 58;
+
+        FileBlendshapeScaler uut = GetScaler();
+
+        Assert.AreEqual(numberOfEyeParamsSet, uut.GetUsedEyeExpressionShapes().Count);
+        Assert.AreEqual(numberOfFaceParamsSet, uut.GetUsedUnifiedExpressionShapes().Count);
+    }
+
+    [TestMethod]
+    public void GenerateJsonFileIfNonExistant()
+    {
+        MockFileSystem mockFileSysteme = new MockFileSystem();
+        string filePath = "ModuleConfig.json";
+        Mock<ILogger> logger = new Mock<ILogger>();
+
+        FileBlendshapeScaler uut = new FileBlendshapeScaler(logger.Object, mockFileSysteme, filePath);
+
+        // this should trigger the generaton of the file
+        uut.EyeExpressionShapeScale(0f, EyeExpressions.EyeOpennessRight);
+
+        Assert.IsTrue(mockFileSysteme.File.Exists(filePath));
+        Console.WriteLine("Json contents:\n\n" + mockFileSysteme.File.ReadAllText(filePath));
+    }
+
+    [TestMethod]
+    public void KeepWorkingIfInvalidFileProvided()
+    {
+        MockFileSystem mockFileSysteme = new MockFileSystem();
+        string filePath = "ModuleConfig.json";
+        MockFileData mockFileData = new MockFileData("{\"invalid-data\":null");
+        mockFileSysteme.AddFile(filePath, mockFileData);
+        Mock<ILogger> logger = new Mock<ILogger>();
+        float setting = 0.4f;
+
+        FileBlendshapeScaler uut = new FileBlendshapeScaler(logger.Object, mockFileSysteme, filePath);
+
+        float got = uut.EyeExpressionShapeScale(setting, EyeExpressions.EyeOpennessRight);
+
+        Assert.AreEqual(setting, got, 0.01); // even if the file is wrong, we expect a '*1'
+    }
+
+    [TestMethod]
+    public void ScaleAffectedBlendshapeBySetValue()
+    {
+        Dictionary<EyeExpressions, float> eyeScales = new Dictionary<EyeExpressions, float>();
+        Dictionary<UnifiedExpressions, float> unifiedScales = new Dictionary<UnifiedExpressions, float>();
+        float setting = 0.4f;
+        float scalingByFactor = 1.3f;
+        eyeScales.Add(EyeExpressions.EyeOpennessRight, scalingByFactor);
+        FileBlendshapeScaler uut = GetScalerWithCustomScales(eyeScales, unifiedScales);
+
+        float got = uut.EyeExpressionShapeScale(setting, EyeExpressions.EyeOpennessRight);
+
+        Assert.AreEqual(setting * scalingByFactor, got, 0.01);
+    }
+
+
+    [TestMethod]
+    public void DefaultScaleTo1ToUnaffectedBlendshapes()
+    {
+        float setting = 0.4f;
+        FileBlendshapeScaler uut = GetScaler();
+
+        float got = uut.EyeExpressionShapeScale(setting, EyeExpressions.EyeOpennessRight);
+
+        Assert.AreEqual(setting, got, 0.01);
+    }
+}

--- a/PicoStreamingAssistantFTTests/Pico4ModuleShould.cs
+++ b/PicoStreamingAssistantFTTests/Pico4ModuleShould.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Pico4SAFTExtTrackingModule.BlendshapeScaler;
+using Pico4SAFTExtTrackingModule.PicoConnectors;
+using VRCFaceTracking.Core.Library;
+using VRCFaceTracking.Core.Params.Expressions;
+
+namespace Pico4SAFTExtTrackingModule;
+
+[TestClass]
+public class Pico4ModuleShould
+{
+    private static Mock<IBlendshapeScaler> GetScalerMock()
+    {
+        Mock<IBlendshapeScaler> logger = new Mock<IBlendshapeScaler>();
+        logger.Setup(m => m.EyeExpressionShapeScale(It.IsAny<float>(), It.IsAny<EyeExpressions>()))
+            .Returns((float val, EyeExpressions _) => { return val; });
+        logger.Setup(m => m.UnifiedExpressionShapeScale(It.IsAny<float>(), It.IsAny<UnifiedExpressions>()))
+            .Returns((float val, UnifiedExpressions _) => { return val; });
+        return logger;
+    }
+
+    [TestMethod]
+    public unsafe void ApplyScalingToShapes()
+    {
+        int numberOfEyeParamsSet = 6,
+            numberOfFaceParamsSet = 58;
+
+        IPicoConnector pxrFTInfoMock = new IPicoConnectorMock();
+        Mock<IBlendshapeScaler> scalerMock = GetScalerMock();
+        Pico4SAFTExtTrackingModule uut = new Pico4SAFTExtTrackingModule(pxrFTInfoMock, scalerMock.Object);
+        // simulate the `Setup` has been called
+        uut.Status = ModuleState.Active;
+        uut.trackingState = (true, true);
+
+        // act
+        uut.Update();
+
+        // assert
+        scalerMock.Verify(m => m.EyeExpressionShapeScale(It.IsAny<float>(), It.IsAny<EyeExpressions>()), Times.Exactly(numberOfEyeParamsSet));
+        scalerMock.Verify(m => m.UnifiedExpressionShapeScale(It.IsAny<float>(), It.IsAny<UnifiedExpressions>()), Times.Exactly(numberOfFaceParamsSet));
+    }
+
+
+
+    private class IPicoConnectorMock : IPicoConnector
+    {
+        private PxrFTInfo getBlendShapesReturn;
+
+        public IPicoConnectorMock()
+        {
+            this.getBlendShapesReturn = new PxrFTInfo();
+        }
+
+        public IPicoConnectorMock(PxrFTInfo getBlendShapesReturn)
+        {
+            this.getBlendShapesReturn = getBlendShapesReturn;
+        }
+
+        public bool Connect()
+        {
+            throw new NotImplementedException();
+        }
+
+        public unsafe float* GetBlendShapes()
+        {
+            fixed (PxrFTInfo* pData = &this.getBlendShapesReturn)
+                return pData->blendShapeWeight;
+        }
+
+        public string GetProcessName()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Teardown()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/PicoStreamingAssistantFTTests/PicoStreamingAssistantFTTests.csproj
+++ b/PicoStreamingAssistantFTTests/PicoStreamingAssistantFTTests.csproj
@@ -7,6 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PicoStreamingAssistantFTUDP/BlendshapeScaler/EyeExpressions.cs
+++ b/PicoStreamingAssistantFTUDP/BlendshapeScaler/EyeExpressions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pico4SAFTExtTrackingModule.BlendshapeScaler;
+
+public enum EyeExpressions
+{
+    #region Eye Gaze Expressions
+
+    EyeXGazeRight,
+    EyeYGazeRight,
+    EyeXGazeLeft,
+    EyeYGazeLeft,
+
+    #endregion
+
+    #region Eye Expressions
+
+    EyeOpennessRight, // Open the right eyelid
+    EyeOpennessLeft, // Open the left eyelid
+    EyeDilationRight, // Dilates the right eye's pupil
+    EyeDilationLeft // Dilates the left eye's pupil
+
+    #endregion
+}

--- a/PicoStreamingAssistantFTUDP/BlendshapeScaler/FileBlendshapeScaler.cs
+++ b/PicoStreamingAssistantFTUDP/BlendshapeScaler/FileBlendshapeScaler.cs
@@ -1,0 +1,217 @@
+﻿using System.Globalization;
+using System.IO.Abstractions;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Serialization;
+using VRCFaceTracking.Core.Params.Expressions;
+
+namespace Pico4SAFTExtTrackingModule.BlendshapeScaler;
+
+public class FileBlendshapeScaler : IBlendshapeScaler
+{
+    private ILogger? Logger;
+    private IFileSystem fileSystem;
+    private string configPath;
+
+    private Dictionary<EyeExpressions, float>? eyeScales;
+    private Dictionary<UnifiedExpressions, float>? unifiedScales;
+
+    public FileBlendshapeScaler(ILogger? logger, IFileSystem fileSystem, string configPath)
+    {
+        this.Logger = logger;
+        this.fileSystem = fileSystem;
+        this.configPath = configPath;
+
+        this.eyeScales = null;
+        this.unifiedScales = null;
+    }
+
+    public bool LoadConfigFile()
+    {
+        this.eyeScales = new Dictionary<EyeExpressions, float>();
+        this.unifiedScales = new Dictionary<UnifiedExpressions, float>();
+
+        if (!this.fileSystem.File.Exists(this.configPath))
+        {
+            bool createResult = this.CreateConfigFile();
+            if (!createResult) return false; // failed
+        }
+
+        try
+        {
+            string stringifiedJson = this.fileSystem.File.ReadAllText(this.configPath);
+            JsonElement scales = JsonDocument.Parse(stringifiedJson).RootElement.GetProperty("scales");
+            foreach (var jsonProperty in scales.EnumerateObject())
+            {
+                if (Logger != null) Logger.LogDebug("Trying to parse {}...", jsonProperty.Name);
+                EyeExpressions eyeExpression;
+                if (Enum.TryParse<EyeExpressions>(jsonProperty.Name, out eyeExpression))
+                {
+                    if (Logger != null) Logger.LogDebug("{} matches as EyeExpression! Set its scaling to {}", jsonProperty.Name, jsonProperty.Value.ToString());
+                    this.eyeScales.Add(eyeExpression, jsonProperty.Value.GetSingle());
+                }
+                UnifiedExpressions unifiedExpression;
+                if (Enum.TryParse<UnifiedExpressions>(jsonProperty.Name, out unifiedExpression))
+                {
+                    if (Logger != null) Logger.LogDebug("{} matches as UnifiedExpression! Set its scaling to {}", jsonProperty.Name, jsonProperty.Value.ToString());
+                    this.unifiedScales.Add(unifiedExpression, jsonProperty.Value.GetSingle());
+                }
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            if (Logger != null) Logger.LogError(ex.ToString());
+            return false;
+        }
+    }
+
+    private bool CreateConfigFile()
+    {
+        if (Logger != null) Logger.LogInformation("Generating blendshape scaling config file...");
+
+        StringBuilder sb = new StringBuilder();
+        NumberFormatInfo nfi = new System.Globalization.NumberFormatInfo();
+        nfi.NumberDecimalSeparator = ".";
+
+        sb.Append("{\n\t\"scales\": {\n");
+
+        foreach (EyeExpressions ee in this.GetUsedEyeExpressionShapes())
+        {
+            sb.Append("\t\t\"")
+                .Append(ee.ToString())
+                .Append("\": 1.00,\n");
+        }
+
+        foreach (UnifiedExpressions ue in this.GetUsedUnifiedExpressionShapes())
+        {
+            sb.Append("\t\t\"")
+                .Append(ue.ToString())
+                .Append("\": 1.00,\n");
+        }
+
+        if (sb.Length > 0)
+        {
+            // not empty; we have to remove the last ','
+            sb.Length = sb.Length - 2;
+            sb.Append('\n');
+        }
+
+        sb.Append("\t}\n}");
+
+        try
+        {
+            this.fileSystem.File.WriteAllText(this.configPath, sb.ToString());
+            return true;
+        }
+        catch (Exception ex) {
+            if (Logger != null) Logger.LogError(ex.ToString());
+            return false;
+        }
+    }
+
+    public float EyeExpressionShapeScale(float val, EyeExpressions type)
+    {
+        if (this.eyeScales == null)
+        {
+            bool loaded = LoadConfigFile();
+            if (!loaded || this.eyeScales == null) return val; // couldn't load; expect a '*1' multiplier
+        }
+
+        float scale;
+        if (!this.eyeScales.TryGetValue(type, out scale)) scale = 1.0f; // property not set
+        return val * scale;
+    }
+
+    public float UnifiedExpressionShapeScale(float val, UnifiedExpressions type)
+    {
+        if (this.unifiedScales == null)
+        {
+            bool loaded = LoadConfigFile();
+            if (!loaded || this.unifiedScales == null) return val; // couldn't load; expect a '*1' multiplier
+        }
+
+        float scale;
+        if (!this.unifiedScales.TryGetValue(type, out scale)) scale = 1.0f; // property not set
+        return val * scale;
+    }
+
+    public List<EyeExpressions> GetUsedEyeExpressionShapes()
+    {
+        return new List<EyeExpressions>()
+        {
+            EyeExpressions.EyeXGazeRight,
+            EyeExpressions.EyeYGazeRight,
+            EyeExpressions.EyeXGazeLeft,
+            EyeExpressions.EyeYGazeLeft,
+            EyeExpressions.EyeOpennessRight,
+            EyeExpressions.EyeOpennessLeft
+        };
+    }
+
+    public List<UnifiedExpressions> GetUsedUnifiedExpressionShapes()
+    {
+        return new List<UnifiedExpressions>()
+        {
+            UnifiedExpressions.BrowInnerUpLeft,
+            UnifiedExpressions.BrowInnerUpRight,
+            UnifiedExpressions.BrowOuterUpLeft,
+            UnifiedExpressions.BrowOuterUpRight,
+            UnifiedExpressions.BrowLowererLeft,
+            UnifiedExpressions.BrowPinchLeft,
+            UnifiedExpressions.BrowLowererRight,
+            UnifiedExpressions.BrowPinchRight,
+            UnifiedExpressions.EyeSquintLeft,
+            UnifiedExpressions.EyeSquintRight,
+            UnifiedExpressions.EyeWideLeft,
+            UnifiedExpressions.EyeWideRight,
+            UnifiedExpressions.JawOpen,
+            UnifiedExpressions.JawLeft,
+            UnifiedExpressions.JawRight,
+            UnifiedExpressions.JawForward,
+            UnifiedExpressions.MouthClosed,
+            UnifiedExpressions.CheekPuffLeft,
+            UnifiedExpressions.CheekPuffRight,
+            UnifiedExpressions.CheekSquintLeft,
+            UnifiedExpressions.CheekSquintRight,
+            UnifiedExpressions.NoseSneerLeft,
+            UnifiedExpressions.NoseSneerRight,
+            UnifiedExpressions.MouthUpperUpLeft,
+            UnifiedExpressions.MouthUpperUpRight,
+            UnifiedExpressions.MouthLowerDownLeft,
+            UnifiedExpressions.MouthLowerDownRight,
+            UnifiedExpressions.MouthFrownLeft,
+            UnifiedExpressions.MouthFrownRight,
+            UnifiedExpressions.MouthDimpleLeft,
+            UnifiedExpressions.MouthDimpleRight,
+            UnifiedExpressions.MouthUpperLeft,
+            UnifiedExpressions.MouthLowerLeft,
+            UnifiedExpressions.MouthUpperRight,
+            UnifiedExpressions.MouthLowerRight,
+            UnifiedExpressions.MouthPressLeft,
+            UnifiedExpressions.MouthPressRight,
+            UnifiedExpressions.MouthRaiserLower,
+            UnifiedExpressions.MouthRaiserUpper,
+            UnifiedExpressions.MouthCornerPullLeft,
+            UnifiedExpressions.MouthCornerSlantLeft,
+            UnifiedExpressions.MouthCornerPullRight,
+            UnifiedExpressions.MouthCornerSlantRight,
+            UnifiedExpressions.MouthStretchLeft,
+            UnifiedExpressions.MouthStretchRight,
+            UnifiedExpressions.LipFunnelUpperLeft,
+            UnifiedExpressions.LipFunnelUpperRight,
+            UnifiedExpressions.LipFunnelLowerLeft,
+            UnifiedExpressions.LipFunnelLowerRight,
+            UnifiedExpressions.LipPuckerUpperLeft,
+            UnifiedExpressions.LipPuckerUpperRight,
+            UnifiedExpressions.LipPuckerLowerLeft,
+            UnifiedExpressions.LipPuckerLowerRight,
+            UnifiedExpressions.LipSuckUpperLeft,
+            UnifiedExpressions.LipSuckUpperRight,
+            UnifiedExpressions.LipSuckLowerLeft,
+            UnifiedExpressions.LipSuckLowerRight,
+            UnifiedExpressions.TongueOut
+        };
+    }
+}

--- a/PicoStreamingAssistantFTUDP/BlendshapeScaler/FileBlendshapeScalerFactory.cs
+++ b/PicoStreamingAssistantFTUDP/BlendshapeScaler/FileBlendshapeScalerFactory.cs
@@ -15,6 +15,14 @@ public class FileBlendshapeScalerFactory
 
     public IBlendshapeScaler build(ILogger Logger)
     {
-        return new FileBlendshapeScaler(Logger, new FileSystem(), ModuleConfigPath.FullPath);
+        IBlendshapeScaler scaler = new FileBlendshapeScaler(Logger, new FileSystem(), ModuleConfigPath.FullPath);
+        IBlendshapeScaler scalerLimiter = new ScalerLimiter(scaler);
+
+        if (!((FileBlendshapeScaler)scaler).LoadConfigFile())
+        {
+            Logger.LogWarning("Failed to load/create module config file.");
+        }
+
+        return scalerLimiter;
     }
 }

--- a/PicoStreamingAssistantFTUDP/BlendshapeScaler/FileBlendshapeScalerFactory.cs
+++ b/PicoStreamingAssistantFTUDP/BlendshapeScaler/FileBlendshapeScalerFactory.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.Logging;
+using System.IO.Abstractions;
+using System.Reflection;
+
+namespace Pico4SAFTExtTrackingModule.BlendshapeScaler;
+
+public class FileBlendshapeScalerFactory
+{
+    private static class ModuleConfigPath
+    {
+        public const string Filename = "PicoModuleConfig.json";
+        public static string Directory => Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        public static string FullPath => Path.Combine(ModuleConfigPath.Directory, ModuleConfigPath.Filename);
+    }
+
+    public IBlendshapeScaler build(ILogger Logger)
+    {
+        return new FileBlendshapeScaler(Logger, new FileSystem(), ModuleConfigPath.FullPath);
+    }
+}

--- a/PicoStreamingAssistantFTUDP/BlendshapeScaler/IBlendshapeScaler.cs
+++ b/PicoStreamingAssistantFTUDP/BlendshapeScaler/IBlendshapeScaler.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VRCFaceTracking.Core.Params.Expressions;
+
+namespace Pico4SAFTExtTrackingModule.BlendshapeScaler;
+
+public interface IBlendshapeScaler
+{
+    float EyeExpressionShapeScale(float val, EyeExpressions type);
+    float UnifiedExpressionShapeScale(float val, UnifiedExpressions type);
+
+    List<EyeExpressions> GetUsedEyeExpressionShapes();
+    List<UnifiedExpressions> GetUsedUnifiedExpressionShapes();
+}

--- a/PicoStreamingAssistantFTUDP/BlendshapeScaler/ScalerLimiter.cs
+++ b/PicoStreamingAssistantFTUDP/BlendshapeScaler/ScalerLimiter.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VRCFaceTracking.Core.Params.Expressions;
+
+namespace Pico4SAFTExtTrackingModule.BlendshapeScaler;
+
+/**
+ * As VRC will go crazy if the param goes above 1.0f or below -1.0f,
+ * this class will truncate the output.
+ **/
+public class ScalerLimiter : IBlendshapeScaler
+{
+    public static readonly float UPPER_LIMIT = 0.99f;
+    public static readonly float LOWER_LIMIT = -0.99f;
+
+    private IBlendshapeScaler limiting;
+    public ScalerLimiter(IBlendshapeScaler limiting)
+    {
+        this.limiting = limiting;
+    }
+
+    public static float Filter(float val)
+    {
+        if (val > UPPER_LIMIT) val = UPPER_LIMIT;
+        else if (val < LOWER_LIMIT) val = LOWER_LIMIT;
+        return val;
+    }
+
+    public float EyeExpressionShapeScale(float val, EyeExpressions type)
+    {
+        return Filter(this.limiting.EyeExpressionShapeScale(val, type));
+    }
+
+    public float UnifiedExpressionShapeScale(float val, UnifiedExpressions type)
+    {
+        return Filter(this.limiting.UnifiedExpressionShapeScale(val, type));
+    }
+
+    public List<EyeExpressions> GetUsedEyeExpressionShapes()
+    {
+        return this.limiting.GetUsedEyeExpressionShapes();
+    }
+
+    public List<UnifiedExpressions> GetUsedUnifiedExpressionShapes()
+    {
+        return this.limiting.GetUsedUnifiedExpressionShapes();
+    }
+}

--- a/PicoStreamingAssistantFTUDP/PacketLogger/PicoDataLoggerFactory.cs
+++ b/PicoStreamingAssistantFTUDP/PacketLogger/PicoDataLoggerFactory.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Text;
 using Pico4SAFTExtTrackingModule.PicoConnectors;
+using System.Runtime.CompilerServices;
 
 namespace Pico4SAFTExtTrackingModule.PacketLogger;
 
@@ -14,13 +10,7 @@ public sealed class PicoDataLoggerFactory
     {
         public unsafe void Clone(PxrFTInfo *obj, PxrFTInfo* ret)
         {
-            ret->timestamp = obj->timestamp;
-            ret->laughingProb = obj->laughingProb;
-
-            // TODO I'm sure there's an equivalent of `memcpy` for C# but I couldn't find it
-            for (int n = 0; n < Pxr.BLEND_SHAPE_NUMS; n++) ret->blendShapeWeight[n] = obj->blendShapeWeight[n];
-            for (int n = 0; n < 10; n++) ret->videoInputValid[n] = obj->videoInputValid[n];
-            for (int n = 0; n < 10; n++) ret->emotionProb[n] = obj->emotionProb[n];
+            Unsafe.CopyBlock(ret, obj, (uint)sizeof(PxrFTInfo));
         }
 
         public string GetCSVHeader(char delimiter)

--- a/PicoStreamingAssistantFTUDP/Pico4SAFTExtTrackingModule.cs
+++ b/PicoStreamingAssistantFTUDP/Pico4SAFTExtTrackingModule.cs
@@ -74,10 +74,6 @@ public sealed class Pico4SAFTExtTrackingModule : ExtTrackingModule, IDisposable
         }
 
         this.scaler = new FileBlendshapeScalerFactory().build(Logger);
-        if (!((FileBlendshapeScaler)this.scaler).LoadConfigFile())
-        {
-            Logger.LogWarning("Failed to load/create module config file.");
-        }
 
         if (FILE_LOG)
         {

--- a/PicoStreamingAssistantFTUDP/Pico4SAFTExtTrackingModule.cs
+++ b/PicoStreamingAssistantFTUDP/Pico4SAFTExtTrackingModule.cs
@@ -10,6 +10,7 @@ using VRCFaceTracking.Core.Params.Data;
 using VRCFaceTracking.Core.Params.Expressions;
 using Pico4SAFTExtTrackingModule.PicoConnectors.ProgramChecker;
 using Pico4SAFTExtTrackingModule.PicoConnectors.ConfigChecker;
+using Pico4SAFTExtTrackingModule.BlendshapeScaler;
 
 namespace Pico4SAFTExtTrackingModule;
 
@@ -17,13 +18,30 @@ public sealed class Pico4SAFTExtTrackingModule : ExtTrackingModule, IDisposable
 {
     private bool disposedValue;
     private IPicoConnector? connector;
-    private (bool, bool) trackingState = (false, false);
+    private IBlendshapeScaler? scaler;
+    public (bool, bool) trackingState = (false, false);
 
     private const bool FILE_LOG = false;
     public static readonly string LOGGER_PATH = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "VRCFaceTracking\\PICOLogs.csv");
     private PacketLogger<PxrFTInfo>? logger;
 
     public override (bool SupportsEye, bool SupportsExpression) Supported { get; } = (true, true);
+
+    public Pico4SAFTExtTrackingModule()
+    {
+        this.connector = null;
+        this.scaler = null;
+        this.logger = null;
+        this.disposedValue = false;
+    }
+
+    public Pico4SAFTExtTrackingModule(IPicoConnector connector, IBlendshapeScaler scaler)
+    {
+        this.connector = connector;
+        this.scaler = scaler;
+        this.logger = null;
+        this.disposedValue = false;
+    }
 
     private bool StreamerValidity()
     {
@@ -55,6 +73,12 @@ public sealed class Pico4SAFTExtTrackingModule : ExtTrackingModule, IDisposable
             return (false, false);
         }
 
+        this.scaler = new FileBlendshapeScalerFactory().build(Logger);
+        if (!((FileBlendshapeScaler)this.scaler).LoadConfigFile())
+        {
+            Logger.LogWarning("Failed to load/create module config file.");
+        }
+
         if (FILE_LOG)
         {
             this.logger = PicoDataLoggerFactory.build(LOGGER_PATH);
@@ -74,100 +98,100 @@ public sealed class Pico4SAFTExtTrackingModule : ExtTrackingModule, IDisposable
         return trackingState;
     }
 
-    private static unsafe void UpdateEye(float* pxrShape, UnifiedSingleEyeData* left, UnifiedSingleEyeData* right)
+    private unsafe void UpdateEye(float* pxrShape, UnifiedSingleEyeData* left, UnifiedSingleEyeData* right)
     {
         // to be tested, not entirely sure how Pxr blink/squint will translate to Openness.
-        left->Openness = 1f - pxrShape[(int)BlendShapeIndex.EyeBlink_L];
-        right->Openness = 1f - pxrShape[(int)BlendShapeIndex.EyeBlink_R];
+        left->Openness = this.scaler!.EyeExpressionShapeScale(1f - pxrShape[(int)BlendShapeIndex.EyeBlink_L], EyeExpressions.EyeOpennessLeft);
+        right->Openness = this.scaler!.EyeExpressionShapeScale(1f - pxrShape[(int)BlendShapeIndex.EyeBlink_R], EyeExpressions.EyeOpennessRight);
 
-        left->Gaze.x = pxrShape[(int)BlendShapeIndex.EyeLookIn_L] - pxrShape[(int)BlendShapeIndex.EyeLookOut_L];
-        left->Gaze.y = pxrShape[(int)BlendShapeIndex.EyeLookUp_L] - pxrShape[(int)BlendShapeIndex.EyeLookDown_L];
+        left->Gaze.x = this.scaler!.EyeExpressionShapeScale(pxrShape[(int)BlendShapeIndex.EyeLookIn_L] - pxrShape[(int)BlendShapeIndex.EyeLookOut_L], EyeExpressions.EyeXGazeLeft);
+        left->Gaze.y = this.scaler!.EyeExpressionShapeScale(pxrShape[(int)BlendShapeIndex.EyeLookUp_L] - pxrShape[(int)BlendShapeIndex.EyeLookDown_L], EyeExpressions.EyeYGazeLeft);
 
-        right->Gaze.x = pxrShape[(int)BlendShapeIndex.EyeLookOut_R] - pxrShape[(int)BlendShapeIndex.EyeLookIn_R];
-        right->Gaze.y = pxrShape[(int)BlendShapeIndex.EyeLookUp_R] - pxrShape[(int)BlendShapeIndex.EyeLookDown_R];
+        right->Gaze.x = this.scaler!.EyeExpressionShapeScale(pxrShape[(int)BlendShapeIndex.EyeLookOut_R] - pxrShape[(int)BlendShapeIndex.EyeLookIn_R], EyeExpressions.EyeXGazeRight);
+        right->Gaze.y = this.scaler!.EyeExpressionShapeScale(pxrShape[(int)BlendShapeIndex.EyeLookUp_R] - pxrShape[(int)BlendShapeIndex.EyeLookDown_R], EyeExpressions.EyeXGazeLeft);
     }
 
-    private static unsafe void UpdateEyeExpression(float* pxrShape, UnifiedExpressionShape* unifiedShape)
+    private unsafe void UpdateEyeExpression(float* pxrShape, UnifiedExpressionShape* unifiedShape)
     {
         #region Brow Shapes
-        unifiedShape[(int)UnifiedExpressions.BrowInnerUpLeft].Weight = pxrShape[(int)BlendShapeIndex.BrowInnerUp];
-        unifiedShape[(int)UnifiedExpressions.BrowInnerUpRight].Weight = pxrShape[(int)BlendShapeIndex.BrowInnerUp];
-        unifiedShape[(int)UnifiedExpressions.BrowOuterUpLeft].Weight = pxrShape[(int)BlendShapeIndex.BrowOuterUp_L];
-        unifiedShape[(int)UnifiedExpressions.BrowOuterUpRight].Weight = pxrShape[(int)BlendShapeIndex.BrowOuterUp_R];
-        unifiedShape[(int)UnifiedExpressions.BrowLowererLeft].Weight = pxrShape[(int)BlendShapeIndex.BrowDown_L];
-        unifiedShape[(int)UnifiedExpressions.BrowPinchLeft].Weight = pxrShape[(int)BlendShapeIndex.BrowDown_L];
-        unifiedShape[(int)UnifiedExpressions.BrowLowererRight].Weight = pxrShape[(int)BlendShapeIndex.BrowDown_R];
-        unifiedShape[(int)UnifiedExpressions.BrowPinchRight].Weight = pxrShape[(int)BlendShapeIndex.BrowDown_R];
+        unifiedShape[(int)UnifiedExpressions.BrowInnerUpLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.BrowInnerUp], UnifiedExpressions.BrowInnerUpLeft);
+        unifiedShape[(int)UnifiedExpressions.BrowInnerUpRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.BrowInnerUp], UnifiedExpressions.BrowInnerUpRight);
+        unifiedShape[(int)UnifiedExpressions.BrowOuterUpLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.BrowOuterUp_L], UnifiedExpressions.BrowOuterUpLeft);
+        unifiedShape[(int)UnifiedExpressions.BrowOuterUpRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.BrowOuterUp_R], UnifiedExpressions.BrowOuterUpRight);
+        unifiedShape[(int)UnifiedExpressions.BrowLowererLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.BrowDown_L], UnifiedExpressions.BrowLowererLeft);
+        unifiedShape[(int)UnifiedExpressions.BrowPinchLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.BrowDown_L], UnifiedExpressions.BrowPinchLeft);
+        unifiedShape[(int)UnifiedExpressions.BrowLowererRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.BrowDown_R], UnifiedExpressions.BrowLowererRight);
+        unifiedShape[(int)UnifiedExpressions.BrowPinchRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.BrowDown_R], UnifiedExpressions.BrowPinchRight);
         #endregion
         #region Eye Shapes
-        unifiedShape[(int)UnifiedExpressions.EyeSquintLeft].Weight = pxrShape[(int)BlendShapeIndex.EyeSquint_L];
-        unifiedShape[(int)UnifiedExpressions.EyeSquintRight].Weight = pxrShape[(int)BlendShapeIndex.EyeSquint_R];
-        unifiedShape[(int)UnifiedExpressions.EyeWideLeft].Weight = pxrShape[(int)BlendShapeIndex.EyeWide_L];
-        unifiedShape[(int)UnifiedExpressions.EyeWideRight].Weight = pxrShape[(int)BlendShapeIndex.EyeWide_R];
+        unifiedShape[(int)UnifiedExpressions.EyeSquintLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.EyeSquint_L], UnifiedExpressions.EyeSquintLeft);
+        unifiedShape[(int)UnifiedExpressions.EyeSquintRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.EyeSquint_R], UnifiedExpressions.EyeSquintRight);
+        unifiedShape[(int)UnifiedExpressions.EyeWideLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.EyeWide_L], UnifiedExpressions.EyeWideLeft);
+        unifiedShape[(int)UnifiedExpressions.EyeWideRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.EyeWide_R], UnifiedExpressions.EyeWideRight);
         #endregion
     }
 
-    private static unsafe void UpdateExpression(float* pxrShape, UnifiedExpressionShape* unifiedShape)
+    private unsafe void UpdateExpression(float* pxrShape, UnifiedExpressionShape* unifiedShape)
     {
         // TODO: Map Viseme shapes onto face shapes.
 
         #region Jaw
-        unifiedShape[(int)UnifiedExpressions.JawOpen].Weight = pxrShape[(int)BlendShapeIndex.JawOpen];
-        unifiedShape[(int)UnifiedExpressions.JawLeft].Weight = pxrShape[(int)BlendShapeIndex.JawLeft];
-        unifiedShape[(int)UnifiedExpressions.JawRight].Weight = pxrShape[(int)BlendShapeIndex.JawRight];
-        unifiedShape[(int)UnifiedExpressions.JawForward].Weight = pxrShape[(int)BlendShapeIndex.JawForward];
-        unifiedShape[(int)UnifiedExpressions.MouthClosed].Weight = pxrShape[(int)BlendShapeIndex.MouthClose];
+        unifiedShape[(int)UnifiedExpressions.JawOpen].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.JawOpen], UnifiedExpressions.JawOpen);
+        unifiedShape[(int)UnifiedExpressions.JawLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.JawLeft], UnifiedExpressions.JawLeft);
+        unifiedShape[(int)UnifiedExpressions.JawRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.JawRight], UnifiedExpressions.JawRight);
+        unifiedShape[(int)UnifiedExpressions.JawForward].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.JawForward], UnifiedExpressions.JawForward);
+        unifiedShape[(int)UnifiedExpressions.MouthClosed].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthClose], UnifiedExpressions.MouthClosed);
         #endregion
         #region Cheek
-        unifiedShape[(int)UnifiedExpressions.CheekPuffLeft].Weight = pxrShape[(int)BlendShapeIndex.CheekPuff];
-        unifiedShape[(int)UnifiedExpressions.CheekPuffRight].Weight = pxrShape[(int)BlendShapeIndex.CheekPuff];
-        unifiedShape[(int)UnifiedExpressions.CheekSquintLeft].Weight = pxrShape[(int)BlendShapeIndex.CheekSquint_L];
-        unifiedShape[(int)UnifiedExpressions.CheekSquintRight].Weight = pxrShape[(int)BlendShapeIndex.CheekSquint_R];
+        unifiedShape[(int)UnifiedExpressions.CheekPuffLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.CheekPuff], UnifiedExpressions.CheekPuffLeft);
+        unifiedShape[(int)UnifiedExpressions.CheekPuffRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.CheekPuff], UnifiedExpressions.CheekPuffRight);
+        unifiedShape[(int)UnifiedExpressions.CheekSquintLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.CheekSquint_L], UnifiedExpressions.CheekSquintLeft);
+        unifiedShape[(int)UnifiedExpressions.CheekSquintRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.CheekSquint_R], UnifiedExpressions.CheekSquintRight);
         #endregion
         #region Nose
-        unifiedShape[(int)UnifiedExpressions.NoseSneerLeft].Weight = pxrShape[(int)BlendShapeIndex.NoseSneer_L];
-        unifiedShape[(int)UnifiedExpressions.NoseSneerRight].Weight = pxrShape[(int)BlendShapeIndex.NoseSneer_R];
+        unifiedShape[(int)UnifiedExpressions.NoseSneerLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.NoseSneer_L], UnifiedExpressions.NoseSneerLeft);
+        unifiedShape[(int)UnifiedExpressions.NoseSneerRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.NoseSneer_R], UnifiedExpressions.NoseSneerRight);
         #endregion
         #region Mouth
-        unifiedShape[(int)UnifiedExpressions.MouthUpperUpLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthUpperUp_L];
-        unifiedShape[(int)UnifiedExpressions.MouthUpperUpRight].Weight = pxrShape[(int)BlendShapeIndex.MouthUpperUp_R];
-        unifiedShape[(int)UnifiedExpressions.MouthLowerDownLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthLowerDown_L];
-        unifiedShape[(int)UnifiedExpressions.MouthLowerDownRight].Weight = pxrShape[(int)BlendShapeIndex.MouthLowerDown_R];
-        unifiedShape[(int)UnifiedExpressions.MouthFrownLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthFrown_L];
-        unifiedShape[(int)UnifiedExpressions.MouthFrownRight].Weight = pxrShape[(int)BlendShapeIndex.MouthFrown_R];
-        unifiedShape[(int)UnifiedExpressions.MouthDimpleLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthDimple_L];
-        unifiedShape[(int)UnifiedExpressions.MouthDimpleRight].Weight = pxrShape[(int)BlendShapeIndex.MouthDimple_R];
-        unifiedShape[(int)UnifiedExpressions.MouthUpperLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthLeft];
-        unifiedShape[(int)UnifiedExpressions.MouthLowerLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthLeft];
-        unifiedShape[(int)UnifiedExpressions.MouthUpperRight].Weight = pxrShape[(int)BlendShapeIndex.MouthRight];
-        unifiedShape[(int)UnifiedExpressions.MouthLowerRight].Weight = pxrShape[(int)BlendShapeIndex.MouthRight];
-        unifiedShape[(int)UnifiedExpressions.MouthPressLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthPress_L];
-        unifiedShape[(int)UnifiedExpressions.MouthPressRight].Weight = pxrShape[(int)BlendShapeIndex.MouthPress_R];
-        unifiedShape[(int)UnifiedExpressions.MouthRaiserLower].Weight = pxrShape[(int)BlendShapeIndex.MouthShrugLower];
-        unifiedShape[(int)UnifiedExpressions.MouthRaiserUpper].Weight = pxrShape[(int)BlendShapeIndex.MouthShrugUpper];
-        unifiedShape[(int)UnifiedExpressions.MouthCornerPullLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthSmile_L];
-        unifiedShape[(int)UnifiedExpressions.MouthCornerSlantLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthSmile_L];
-        unifiedShape[(int)UnifiedExpressions.MouthCornerPullRight].Weight = pxrShape[(int)BlendShapeIndex.MouthSmile_R];
-        unifiedShape[(int)UnifiedExpressions.MouthCornerSlantRight].Weight = pxrShape[(int)BlendShapeIndex.MouthSmile_R];
-        unifiedShape[(int)UnifiedExpressions.MouthStretchLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthStretch_L];
-        unifiedShape[(int)UnifiedExpressions.MouthStretchRight].Weight = pxrShape[(int)BlendShapeIndex.MouthStretch_R];
+        unifiedShape[(int)UnifiedExpressions.MouthUpperUpLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthUpperUp_L], UnifiedExpressions.MouthUpperUpLeft);
+        unifiedShape[(int)UnifiedExpressions.MouthUpperUpRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthUpperUp_R], UnifiedExpressions.MouthUpperUpRight);
+        unifiedShape[(int)UnifiedExpressions.MouthLowerDownLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthLowerDown_L], UnifiedExpressions.MouthLowerDownLeft);
+        unifiedShape[(int)UnifiedExpressions.MouthLowerDownRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthLowerDown_R], UnifiedExpressions.MouthLowerDownRight);
+        unifiedShape[(int)UnifiedExpressions.MouthFrownLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthFrown_L], UnifiedExpressions.MouthFrownLeft);
+        unifiedShape[(int)UnifiedExpressions.MouthFrownRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthFrown_R], UnifiedExpressions.MouthFrownRight);
+        unifiedShape[(int)UnifiedExpressions.MouthDimpleLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthDimple_L], UnifiedExpressions.MouthDimpleLeft);
+        unifiedShape[(int)UnifiedExpressions.MouthDimpleRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthDimple_R], UnifiedExpressions.MouthDimpleRight);
+        unifiedShape[(int)UnifiedExpressions.MouthUpperLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthLeft], UnifiedExpressions.MouthUpperLeft);
+        unifiedShape[(int)UnifiedExpressions.MouthLowerLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthLeft], UnifiedExpressions.MouthLowerLeft);
+        unifiedShape[(int)UnifiedExpressions.MouthUpperRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthRight], UnifiedExpressions.MouthUpperRight);
+        unifiedShape[(int)UnifiedExpressions.MouthLowerRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthRight], UnifiedExpressions.MouthLowerRight);
+        unifiedShape[(int)UnifiedExpressions.MouthPressLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthPress_L], UnifiedExpressions.MouthPressLeft);
+        unifiedShape[(int)UnifiedExpressions.MouthPressRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthPress_R], UnifiedExpressions.MouthPressRight);
+        unifiedShape[(int)UnifiedExpressions.MouthRaiserLower].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthShrugLower], UnifiedExpressions.MouthRaiserLower);
+        unifiedShape[(int)UnifiedExpressions.MouthRaiserUpper].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthShrugUpper], UnifiedExpressions.MouthRaiserUpper);
+        unifiedShape[(int)UnifiedExpressions.MouthCornerPullLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthSmile_L], UnifiedExpressions.MouthCornerPullLeft);
+        unifiedShape[(int)UnifiedExpressions.MouthCornerSlantLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthSmile_L], UnifiedExpressions.MouthCornerSlantLeft);
+        unifiedShape[(int)UnifiedExpressions.MouthCornerPullRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthSmile_R], UnifiedExpressions.MouthCornerPullRight);
+        unifiedShape[(int)UnifiedExpressions.MouthCornerSlantRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthSmile_R], UnifiedExpressions.MouthCornerSlantRight);
+        unifiedShape[(int)UnifiedExpressions.MouthStretchLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthStretch_L], UnifiedExpressions.MouthStretchLeft);
+        unifiedShape[(int)UnifiedExpressions.MouthStretchRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthStretch_R], UnifiedExpressions.MouthStretchRight);
         #endregion
         #region Lip
-        unifiedShape[(int)UnifiedExpressions.LipFunnelUpperLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthFunnel];
-        unifiedShape[(int)UnifiedExpressions.LipFunnelUpperRight].Weight = pxrShape[(int)BlendShapeIndex.MouthFunnel];
-        unifiedShape[(int)UnifiedExpressions.LipFunnelLowerLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthFunnel];
-        unifiedShape[(int)UnifiedExpressions.LipFunnelLowerRight].Weight = pxrShape[(int)BlendShapeIndex.MouthFunnel];
-        unifiedShape[(int)UnifiedExpressions.LipPuckerUpperLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthPucker];
-        unifiedShape[(int)UnifiedExpressions.LipPuckerUpperRight].Weight = pxrShape[(int)BlendShapeIndex.MouthPucker];
-        unifiedShape[(int)UnifiedExpressions.LipPuckerLowerLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthPucker];
-        unifiedShape[(int)UnifiedExpressions.LipPuckerLowerRight].Weight = pxrShape[(int)BlendShapeIndex.MouthPucker];
-        unifiedShape[(int)UnifiedExpressions.LipSuckUpperLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthRollUpper];
-        unifiedShape[(int)UnifiedExpressions.LipSuckUpperRight].Weight = pxrShape[(int)BlendShapeIndex.MouthRollUpper];
-        unifiedShape[(int)UnifiedExpressions.LipSuckLowerLeft].Weight = pxrShape[(int)BlendShapeIndex.MouthRollLower];
-        unifiedShape[(int)UnifiedExpressions.LipSuckLowerRight].Weight = pxrShape[(int)BlendShapeIndex.MouthRollLower];
+        unifiedShape[(int)UnifiedExpressions.LipFunnelUpperLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthFunnel], UnifiedExpressions.LipFunnelUpperLeft);
+        unifiedShape[(int)UnifiedExpressions.LipFunnelUpperRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthFunnel], UnifiedExpressions.LipFunnelUpperRight);
+        unifiedShape[(int)UnifiedExpressions.LipFunnelLowerLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthFunnel], UnifiedExpressions.LipFunnelLowerLeft);
+        unifiedShape[(int)UnifiedExpressions.LipFunnelLowerRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthFunnel], UnifiedExpressions.LipFunnelLowerRight);
+        unifiedShape[(int)UnifiedExpressions.LipPuckerUpperLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthPucker], UnifiedExpressions.LipPuckerUpperLeft);
+        unifiedShape[(int)UnifiedExpressions.LipPuckerUpperRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthPucker], UnifiedExpressions.LipPuckerUpperRight);
+        unifiedShape[(int)UnifiedExpressions.LipPuckerLowerLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthPucker], UnifiedExpressions.LipPuckerLowerLeft);
+        unifiedShape[(int)UnifiedExpressions.LipPuckerLowerRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthPucker], UnifiedExpressions.LipPuckerLowerRight);
+        unifiedShape[(int)UnifiedExpressions.LipSuckUpperLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthRollUpper], UnifiedExpressions.LipSuckUpperLeft);
+        unifiedShape[(int)UnifiedExpressions.LipSuckUpperRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthRollUpper], UnifiedExpressions.LipSuckUpperRight);
+        unifiedShape[(int)UnifiedExpressions.LipSuckLowerLeft].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthRollLower], UnifiedExpressions.LipSuckLowerLeft);
+        unifiedShape[(int)UnifiedExpressions.LipSuckLowerRight].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.MouthRollLower], UnifiedExpressions.LipSuckLowerRight);
         #endregion
         #region Tongue
-        unifiedShape[(int)UnifiedExpressions.TongueOut].Weight = pxrShape[(int)BlendShapeIndex.TongueOut];
+        unifiedShape[(int)UnifiedExpressions.TongueOut].Weight = this.scaler!.UnifiedExpressionShapeScale(pxrShape[(int)BlendShapeIndex.TongueOut], UnifiedExpressions.TongueOut);
         #endregion
     }
 

--- a/PicoStreamingAssistantFTUDP/SimplifiedSystemIOAbstractions/IFile.cs
+++ b/PicoStreamingAssistantFTUDP/SimplifiedSystemIOAbstractions/IFile.cs
@@ -3,4 +3,6 @@
 public interface IFile
 {
     public string ReadAllText(string path);
+    public bool Exists(string path);
+    public void WriteAllText(string path, string? contents);
 }

--- a/PicoStreamingAssistantFTUDP/SimplifiedSystemIOAbstractions/MockImplementation/MockFileData.cs
+++ b/PicoStreamingAssistantFTUDP/SimplifiedSystemIOAbstractions/MockImplementation/MockFileData.cs
@@ -2,9 +2,9 @@
 
 public sealed class MockFileData
 {
-    public string Contents { get; private set; }
+    public string? Contents { get; private set; }
 
-    public MockFileData(string contents) {
+    public MockFileData(string? contents) {
         this.Contents = contents;
     }
 }

--- a/PicoStreamingAssistantFTUDP/SimplifiedSystemIOAbstractions/MockImplementation/MockFileSystem.cs
+++ b/PicoStreamingAssistantFTUDP/SimplifiedSystemIOAbstractions/MockImplementation/MockFileSystem.cs
@@ -13,7 +13,7 @@ public sealed class MockFileSystem : IFileSystem, IFile
 
     public void AddFile(string path, MockFileData file)
     {
-        this._contents.Add(path, file.Contents);
+        this._contents.Add(path, file.Contents == null ? "" : file.Contents);
     }
 
     public string ReadAllText(string path)
@@ -23,5 +23,15 @@ public sealed class MockFileSystem : IFileSystem, IFile
         if (!found) throw new FileNotFoundException("Couldn't find any file on " + path);
 
         return text;
+    }
+
+    public bool Exists(string path)
+    {
+        return this._contents.ContainsKey(path);
+    }
+
+    public void WriteAllText(string path, string? contents)
+    {
+        this.AddFile(path, new MockFileData(contents));
     }
 }

--- a/PicoStreamingAssistantFTUDP/SimplifiedSystemIOAbstractions/OSImplementation/FileSystem.cs
+++ b/PicoStreamingAssistantFTUDP/SimplifiedSystemIOAbstractions/OSImplementation/FileSystem.cs
@@ -3,8 +3,18 @@ public sealed class FileSystem : IFileSystem, IFile
 {
     public IFile File => this;
 
+    public bool Exists(string path)
+    {
+        return System.IO.File.Exists(path);
+    }
+
     public string ReadAllText(string path)
     {
         return System.IO.File.ReadAllText(path);
+    }
+
+    public void WriteAllText(string path, string? contents)
+    {
+        System.IO.File.WriteAllText(path, contents);
     }
 }


### PR DESCRIPTION
Added a config file to configure the multiplier applied to each blendshape.

#### Tests

Validated with UT and then tried to launch it for first time on PICO Connect (the default file was generated), and after that I set a property with `<1.0` scaling, and another with `>1.0` scaling; the avatar behaved as expected.