### PR TITLE
Add support for new Business Streaming software

### DIFF
--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/Pico4SAFTExtTrackingModule.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/Pico4SAFTExtTrackingModule.cs
@@ -48,7 +48,7 @@ public sealed class Pico4SAFTExtTrackingModule : ExtTrackingModule, IDisposable
         this.connector = ConnectorFactory.build(Logger, new ProcessRunningProgramChecker(), new ConfigChecker(Logger));
         if (this.connector == null)
         {
-            Logger.LogError("\"Streaming Assistant\", \"Streaming Assistant\" or \"PICO Connect\" process was not found. Please run the Streaming Assistant or PICO Connect before VRCFaceTracking.");
+            Logger.LogError("\"Streaming Assistant\", \"Business Streaming\" or \"PICO Connect\" process was not found. Please run the Streaming Assistant or PICO Connect before VRCFaceTracking.");
             return false;
         }
 

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/PicoConnect/PicoConnectConfigChecker.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/PicoConnect/PicoConnectConfigChecker.cs
@@ -35,7 +35,8 @@ public sealed class PicoConnectConfigChecker : IConfigChecker
 
     public int GetTransferProtocolNumber(PicoPrograms program)
     {
-        if (program != PicoPrograms.PicoConnect) throw new ArgumentException("PicoConnectConfigChecker class only checks for PICO Connect config files");
+        if (program != PicoPrograms.PicoConnect || program != PicoPrograms.BusinessStreaming)
+            throw new ArgumentException("PicoConnectConfigChecker class only checks for PICO Connect or Business Streaming 2.0 config files");
 
         if (picoConfig!.Value == null || picoConfig!.Value.lab == null)
         {

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConnectorFactory.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConnectorFactory.cs
@@ -11,10 +11,12 @@ public sealed class ConnectorFactory
     {
         bool using_sa = programChecker.Check(PicoPrograms.StreamingAssistant);
         bool using_pc = programChecker.Check(PicoPrograms.PicoConnect);
-        bool using_bs = programChecker.Check(PicoPrograms.BusinessStreaming);
+        bool using_old_bs = programChecker.Check(PicoPrograms.BusinessStreamingUW);
+        bool using_new_bs = programChecker.Check(PicoPrograms.BusinessStreaming);
 
         if (using_sa) return new LegacyConnector(Logger, PicoPrograms.StreamingAssistant);
-        else if (using_bs) return new LegacyConnector(Logger, PicoPrograms.BusinessStreaming);
+        else if (using_old_bs) return new LegacyConnector(Logger, PicoPrograms.BusinessStreamingUW);
+        else if (using_new_bs) return new LegacyConnector(Logger, PicoPrograms.BusinessStreaming);
         else if (using_pc)
         {
             try {

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/LegacyConnector.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/LegacyConnector.cs
@@ -47,6 +47,7 @@ public sealed class LegacyConnector : IPicoConnector
                 this.processName = "Streaming Assistant";
                 break;
 
+            case PicoPrograms.BusinessStreamingUW:
             case PicoPrograms.BusinessStreaming:
                 this.processName = "Business Streaming";
                 break;
@@ -110,7 +111,8 @@ public sealed class LegacyConnector : IPicoConnector
         catch (SocketException ex) when (ex.ErrorCode is 10048)
         {
             if (retry >= 3) result = false;
-            else {
+            else
+            {
                 retry++;
                 // Magic
                 // Close the pico_et_ft_bt_bridge.exe process and reinitialize it.

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/PicoPrograms.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/PicoPrograms.cs
@@ -9,6 +9,7 @@ namespace Pico4SAFTExtTrackingModule.PicoConnectors;
 public enum PicoPrograms
 {
     StreamingAssistant,
+    BusinessStreamingUW,
     BusinessStreaming,
     PicoConnect
 }

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ProgramChecker/ProcessRunningProgramChecker.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ProgramChecker/ProcessRunningProgramChecker.cs
@@ -23,8 +23,12 @@ public sealed class ProcessRunningProgramChecker : IProgramChecker
                 processName = "Streaming Assistant";
                 break;
 
-            case PicoPrograms.BusinessStreaming:
+            case PicoPrograms.BusinessStreamingUW:
                 processName = "Business StreamingUW";
+                break;
+
+            case PicoPrograms.BusinessStreaming:
+                processName = "Business Streaming";
                 break;
 
             case PicoPrograms.PicoConnect:


### PR DESCRIPTION
Solves #32 
- Added `BusinessStreamingUW` to `PicoPrograms` to distinguish old and new versions
- `ProcessRunningProgramChecker` checks both "Business Streaming" and "Business StreamingUW" for compatibility
- `PicoConfigChecker/GetTransferProtocolNumber` now also checks Business Streaming 2.0 files