### PR TITLE
Fix/new bs

### DIFF
--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTTests/ConnectorFactoryShould.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTTests/ConnectorFactoryShould.cs
@@ -94,7 +94,29 @@ public class ConnectorFactoryShould
     }
 
     [TestMethod]
-    public void ReturnLegacyConnectorIfBusinessStreamingIsRunning()
+    public void ReturnLegacyConnectorIfOldBusinessStreamingIsRunning()
+    {
+        // arrange
+        Mock<ILogger> logger = new Mock<ILogger>();
+        Mock<IProgramChecker> programCheckerMock = new Mock<IProgramChecker>();
+        programCheckerMock.Setup(m => m.Check(It.IsAny<PicoPrograms>()))
+                        .Returns(false);
+        programCheckerMock.Setup(m => m.Check(PicoPrograms.BusinessStreamingUw))
+                        .Returns(true);
+        Mock<IConfigChecker> configCheckerMock = new Mock<IConfigChecker>();
+        configCheckerMock.Setup(m => m.GetTransferProtocolNumber(It.IsAny<PicoPrograms>()))
+                        .Returns(0);
+
+        // act
+        IPicoConnector? got = ConnectorFactory.build(logger.Object, programCheckerMock.Object, configCheckerMock.Object);
+
+        // assert
+        Assert.AreEqual(typeof(LegacyConnector), got?.GetType());
+        Assert.AreEqual("Business Streaming", got?.GetProcessName());
+    }
+
+    [TestMethod]
+    public void ReturnPicoConnectConnectorIfNewBusinessStreamingIsRunning()
     {
         // arrange
         Mock<ILogger> logger = new Mock<ILogger>();
@@ -106,6 +128,27 @@ public class ConnectorFactoryShould
         Mock<IConfigChecker> configCheckerMock = new Mock<IConfigChecker>();
         configCheckerMock.Setup(m => m.GetTransferProtocolNumber(It.IsAny<PicoPrograms>()))
                         .Returns(0);
+
+        // act
+        IPicoConnector? got = ConnectorFactory.build(logger.Object, programCheckerMock.Object, configCheckerMock.Object);
+
+        // assert
+        Assert.AreEqual(typeof(PicoConnectConnector), got?.GetType());
+    }
+
+    [TestMethod]
+    public void ReturnLegacyConnectorIfNewBusinessStreamingIsRunningAndIsUsingOldTransferProtocol()
+    {
+        // arrange
+        Mock<ILogger> logger = new Mock<ILogger>();
+        Mock<IProgramChecker> programCheckerMock = new Mock<IProgramChecker>();
+        programCheckerMock.Setup(m => m.Check(It.IsAny<PicoPrograms>()))
+                        .Returns(false);
+        programCheckerMock.Setup(m => m.Check(PicoPrograms.BusinessStreaming))
+                        .Returns(true);
+        Mock<IConfigChecker> configCheckerMock = new Mock<IConfigChecker>();
+        configCheckerMock.Setup(m => m.GetTransferProtocolNumber(It.IsAny<PicoPrograms>()))
+                        .Returns(2); // old transfer protocol
 
         // act
         IPicoConnector? got = ConnectorFactory.build(logger.Object, programCheckerMock.Object, configCheckerMock.Object);

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTTests/ConnectorFactoryShould.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTTests/ConnectorFactoryShould.cs
@@ -101,7 +101,7 @@ public class ConnectorFactoryShould
         Mock<IProgramChecker> programCheckerMock = new Mock<IProgramChecker>();
         programCheckerMock.Setup(m => m.Check(It.IsAny<PicoPrograms>()))
                         .Returns(false);
-        programCheckerMock.Setup(m => m.Check(PicoPrograms.BusinessStreamingUw))
+        programCheckerMock.Setup(m => m.Check(PicoPrograms.BusinessStreamingV1))
                         .Returns(true);
         Mock<IConfigChecker> configCheckerMock = new Mock<IConfigChecker>();
         configCheckerMock.Setup(m => m.GetTransferProtocolNumber(It.IsAny<PicoPrograms>()))

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTTests/PicoConnectConfigCheckerShould.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTTests/PicoConnectConfigCheckerShould.cs
@@ -9,7 +9,8 @@ namespace Pico4SAFTExtTrackingModule.PicoConnectors;
 [TestClass]
 public class PicoConnectConfigCheckerShould
 {
-    public static readonly string CONFIG_FILE_PATH = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "PICO Connect\\settings.json");
+    public static readonly string PICO_CONNECT_CONFIG_FILE_PATH = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "PICO Connect\\settings.json");
+    public static readonly string BUSINESS_STREAMING_CONFIG_FILE_PATH = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Business Streaming\\settings.json");
 
     public static Mock<ILogger> GetLoggerMock(List<string> errors)
     {
@@ -54,7 +55,7 @@ public class PicoConnectConfigCheckerShould
 
         MockFileSystem mockFileSysteme = new MockFileSystem();
         MockFileData mockFileData = new MockFileData(GetLegacySettingsJson(0));
-        mockFileSysteme.AddFile(CONFIG_FILE_PATH, mockFileData);
+        mockFileSysteme.AddFile(PICO_CONNECT_CONFIG_FILE_PATH, mockFileData);
 
         PicoConnectConfigChecker uut = new PicoConnectConfigChecker(logger.Object, mockFileSysteme);
 
@@ -75,7 +76,7 @@ public class PicoConnectConfigCheckerShould
 
         MockFileSystem mockFileSysteme = new MockFileSystem();
         MockFileData mockFileData = new MockFileData(GetLegacySettingsJson(2));
-        mockFileSysteme.AddFile(CONFIG_FILE_PATH, mockFileData);
+        mockFileSysteme.AddFile(PICO_CONNECT_CONFIG_FILE_PATH, mockFileData);
 
         PicoConnectConfigChecker uut = new PicoConnectConfigChecker(logger.Object, mockFileSysteme);
 
@@ -96,7 +97,7 @@ public class PicoConnectConfigCheckerShould
 
         MockFileSystem mockFileSysteme = new MockFileSystem();
         MockFileData mockFileData = new MockFileData(GetSettingsJson(0));
-        mockFileSysteme.AddFile(CONFIG_FILE_PATH, mockFileData);
+        mockFileSysteme.AddFile(PICO_CONNECT_CONFIG_FILE_PATH, mockFileData);
 
         PicoConnectConfigChecker uut = new PicoConnectConfigChecker(logger.Object, mockFileSysteme);
 
@@ -117,12 +118,33 @@ public class PicoConnectConfigCheckerShould
 
         MockFileSystem mockFileSysteme = new MockFileSystem();
         MockFileData mockFileData = new MockFileData(GetSettingsJson(2));
-        mockFileSysteme.AddFile(CONFIG_FILE_PATH, mockFileData);
+        mockFileSysteme.AddFile(PICO_CONNECT_CONFIG_FILE_PATH, mockFileData);
 
         PicoConnectConfigChecker uut = new PicoConnectConfigChecker(logger.Object, mockFileSysteme);
 
         // act
         int got = uut.GetTransferProtocolNumber(PicoPrograms.PicoConnect);
+
+        // assert
+        Assert.AreEqual(0, errors.Count, "Expected no errors; instead got:\n" + String.Join("\n", errors));
+        Assert.AreEqual(2, got);
+    }
+
+    [TestMethod]
+    public void ReturnTransferProtocol2WhenBusinessStreamingFileContainsTransferProtocol2()
+    {
+        // arrange
+        List<string> errors = new List<string>();
+        Mock<ILogger> logger = GetLoggerMock(errors);
+
+        MockFileSystem mockFileSysteme = new MockFileSystem();
+        MockFileData mockFileData = new MockFileData(GetSettingsJson(2));
+        mockFileSysteme.AddFile(BUSINESS_STREAMING_CONFIG_FILE_PATH, mockFileData);
+
+        PicoConnectConfigChecker uut = new PicoConnectConfigChecker(logger.Object, mockFileSysteme);
+
+        // act
+        int got = uut.GetTransferProtocolNumber(PicoPrograms.BusinessStreaming);
 
         // assert
         Assert.AreEqual(0, errors.Count, "Expected no errors; instead got:\n" + String.Join("\n", errors));
@@ -157,7 +179,7 @@ public class PicoConnectConfigCheckerShould
 
         MockFileSystem mockFileSysteme = new MockFileSystem();
         MockFileData mockFileData = new MockFileData("{\"data\": \"corrupted");
-        mockFileSysteme.AddFile(CONFIG_FILE_PATH, mockFileData);
+        mockFileSysteme.AddFile(PICO_CONNECT_CONFIG_FILE_PATH, mockFileData);
 
         PicoConnectConfigChecker uut = new PicoConnectConfigChecker(logger.Object, mockFileSysteme);
 
@@ -178,7 +200,7 @@ public class PicoConnectConfigCheckerShould
 
         MockFileSystem mockFileSysteme = new MockFileSystem();
         MockFileData mockFileData = new MockFileData("{\"data\": \"unexpected\"}");
-        mockFileSysteme.AddFile(CONFIG_FILE_PATH, mockFileData);
+        mockFileSysteme.AddFile(PICO_CONNECT_CONFIG_FILE_PATH, mockFileData);
 
         PicoConnectConfigChecker uut = new PicoConnectConfigChecker(logger.Object, mockFileSysteme);
 
@@ -199,7 +221,7 @@ public class PicoConnectConfigCheckerShould
 
         MockFileSystem mockFileSysteme = new MockFileSystem();
         MockFileData mockFileData = new MockFileData("{\"lab\":{\"faceTrackingTransferProtocol\":2}}");
-        mockFileSysteme.AddFile(CONFIG_FILE_PATH, mockFileData);
+        mockFileSysteme.AddFile(PICO_CONNECT_CONFIG_FILE_PATH, mockFileData);
 
         PicoConnectConfigChecker uut = new PicoConnectConfigChecker(logger.Object, mockFileSysteme);
 

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTTests/PicoConnectConfigCheckerShould.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTTests/PicoConnectConfigCheckerShould.cs
@@ -9,8 +9,8 @@ namespace Pico4SAFTExtTrackingModule.PicoConnectors;
 [TestClass]
 public class PicoConnectConfigCheckerShould
 {
-    public static readonly string PICO_CONNECT_CONFIG_FILE_PATH = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "PICO Connect\\settings.json");
-    public static readonly string BUSINESS_STREAMING_CONFIG_FILE_PATH = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Business Streaming\\settings.json");
+    public static readonly string PICO_CONNECT_CONFIG_FILE_PATH = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "PICO Connect", "settings.json");
+    public static readonly string BUSINESS_STREAMING_CONFIG_FILE_PATH = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Business Streaming", "settings.json");
 
     public static Mock<ILogger> GetLoggerMock(List<string> errors)
     {

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/Pico4SAFTExtTrackingModule.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/Pico4SAFTExtTrackingModule.cs
@@ -48,7 +48,7 @@ public sealed class Pico4SAFTExtTrackingModule : ExtTrackingModule, IDisposable
         this.connector = ConnectorFactory.build(Logger, new ProcessRunningProgramChecker(), new ConfigChecker(Logger));
         if (this.connector == null)
         {
-            Logger.LogError("\"Streaming Assistant\", \"Streaming Assistant\" or \"PICO Connect\" process was not found. Please run the Streaming Assistant or PICO Connect before VRCFaceTracking.");
+            Logger.LogError("\"Streaming Assistant\", \"Business Streaming\" or \"PICO Connect\" process was not found. Please run the Streaming Assistant or PICO Connect before VRCFaceTracking.");
             return false;
         }
 

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/ConfigChecker.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/ConfigChecker.cs
@@ -22,6 +22,7 @@ public sealed class ConfigChecker : IConfigChecker
         switch (program)
         {
             case PicoPrograms.PicoConnect:
+            case PicoPrograms.BusinessStreaming:
                 return this.picoConnectConfigChecker.GetTransferProtocolNumber(program);
 
             default:

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/PicoConnect/PicoConnectConfigChecker.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/PicoConnect/PicoConnectConfigChecker.cs
@@ -35,7 +35,8 @@ public sealed class PicoConnectConfigChecker : IConfigChecker
 
     public int GetTransferProtocolNumber(PicoPrograms program)
     {
-        if (program != PicoPrograms.PicoConnect) throw new ArgumentException("PicoConnectConfigChecker class only checks for PICO Connect config files");
+        if (program != PicoPrograms.PicoConnect || program != PicoPrograms.BusinessStreaming)
+            throw new ArgumentException("PicoConnectConfigChecker class only checks for PICO Connect or Business Streaming 2.0 config files");
 
         if (picoConfig!.Value == null || picoConfig!.Value.lab == null)
         {

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/PicoConnect/PicoConnectConfigChecker.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/PicoConnect/PicoConnectConfigChecker.cs
@@ -13,7 +13,6 @@ public sealed class PicoConnectConfigChecker : IConfigChecker
     {
         this.logger = logger;
         this.fileSystem = fileSystem;
-        this.picoConfig = new Lazy<Config>(() => GetConfig(fileSystem, logger));
     }
 
     public PicoConnectConfigChecker(ILogger logger) : this(logger, new FileSystem()) { }
@@ -29,15 +28,14 @@ public sealed class PicoConnectConfigChecker : IConfigChecker
                 return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "PICO Connect");
 
             default:
-                // shouldn't reach this
-                return "";
+                throw new ArgumentException("PicoConnectConfigChecker class only checks for PICO Connect or Business Streaming 2.0 config files");
         }
     }
 
     private static Config GetConfig(IFileSystem fileSystem, PicoPrograms program, ILogger? logger = null)
     {
         string configLocation = Path.Combine(GetProgramFsBasePath(program), "settings.json");
-        logger.LogInformation("Expecting PICO settings file at '" + configLocation + "'");
+        logger?.LogInformation("Expecting PICO settings file at '" + configLocation + "'");
         try
         {
             string configContents = fileSystem.File.ReadAllText(configLocation);

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/PicoConnect/PicoConnectConfigChecker.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/PicoConnect/PicoConnectConfigChecker.cs
@@ -6,20 +6,37 @@ namespace Pico4SAFTExtTrackingModule.PicoConnectors.ConfigChecker.PicoConnect;
 
 public sealed class PicoConnectConfigChecker : IConfigChecker
 {
-    private readonly Lazy<Config> picoConfig;
     private readonly ILogger logger;
+    private readonly IFileSystem fileSystem;
 
     public PicoConnectConfigChecker(ILogger logger, IFileSystem fileSystem)
     {
         this.logger = logger;
+        this.fileSystem = fileSystem;
         this.picoConfig = new Lazy<Config>(() => GetConfig(fileSystem, logger));
     }
 
     public PicoConnectConfigChecker(ILogger logger) : this(logger, new FileSystem()) { }
 
-    private static Config GetConfig(IFileSystem fileSystem, ILogger? logger = null)
+    private static string GetProgramFsBasePath(PicoPrograms program)
     {
-        string configLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "PICO Connect\\settings.json");
+        switch (program)
+        {
+            case PicoPrograms.BusinessStreaming:
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Business Streaming");
+
+            case PicoPrograms.PicoConnect:
+                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "PICO Connect");
+
+            default:
+                // shouldn't reach this
+                return "";
+        }
+    }
+
+    private static Config GetConfig(IFileSystem fileSystem, PicoPrograms program, ILogger? logger = null)
+    {
+        string configLocation = Path.Combine(GetProgramFsBasePath(program), "settings.json");
         logger.LogInformation("Expecting PICO Connect settings file at '" + configLocation + "'");
         try
         {
@@ -38,12 +55,13 @@ public sealed class PicoConnectConfigChecker : IConfigChecker
         if (program != PicoPrograms.PicoConnect && program != PicoPrograms.BusinessStreaming)
             throw new ArgumentException("PicoConnectConfigChecker class only checks for PICO Connect or Business Streaming 2.0 config files");
 
-        if (picoConfig!.Value == null || picoConfig!.Value.lab == null)
+        Config picoConfig = GetConfig(this.fileSystem, program, this.logger);
+        if (picoConfig == null || picoConfig!.lab == null)
         {
             logger.LogError("Couldn't get the value of `faceTrackingTransferProtocol` on the setting.json file");
             return 0; // send default value
         }
 
-        return picoConfig!.Value!.lab!.faceTrackingTransferProtocol;
+        return picoConfig!.lab!.faceTrackingTransferProtocol;
     }
 }

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/PicoConnect/PicoConnectConfigChecker.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/PicoConnect/PicoConnectConfigChecker.cs
@@ -37,7 +37,7 @@ public sealed class PicoConnectConfigChecker : IConfigChecker
     private static Config GetConfig(IFileSystem fileSystem, PicoPrograms program, ILogger? logger = null)
     {
         string configLocation = Path.Combine(GetProgramFsBasePath(program), "settings.json");
-        logger.LogInformation("Expecting PICO Connect settings file at '" + configLocation + "'");
+        logger.LogInformation("Expecting PICO settings file at '" + configLocation + "'");
         try
         {
             string configContents = fileSystem.File.ReadAllText(configLocation);
@@ -45,7 +45,7 @@ public sealed class PicoConnectConfigChecker : IConfigChecker
         }
         catch (Exception ex)
         {
-            logger?.LogError("Pico Connect Config deserialize failed: " + ex.ToString());
+            logger?.LogError("Pico Config deserialize failed: " + ex.ToString());
             return null;
         }
     }

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/PicoConnect/PicoConnectConfigChecker.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConfigChecker/PicoConnect/PicoConnectConfigChecker.cs
@@ -35,7 +35,7 @@ public sealed class PicoConnectConfigChecker : IConfigChecker
 
     public int GetTransferProtocolNumber(PicoPrograms program)
     {
-        if (program != PicoPrograms.PicoConnect || program != PicoPrograms.BusinessStreaming)
+        if (program != PicoPrograms.PicoConnect && program != PicoPrograms.BusinessStreaming)
             throw new ArgumentException("PicoConnectConfigChecker class only checks for PICO Connect or Business Streaming 2.0 config files");
 
         if (picoConfig!.Value == null || picoConfig!.Value.lab == null)

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConnectorFactory.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConnectorFactory.cs
@@ -11,10 +11,12 @@ public sealed class ConnectorFactory
     {
         bool using_sa = programChecker.Check(PicoPrograms.StreamingAssistant);
         bool using_pc = programChecker.Check(PicoPrograms.PicoConnect);
-        bool using_bs = programChecker.Check(PicoPrograms.BusinessStreaming);
+        bool using_old_bs = programChecker.Check(PicoPrograms.BusinessStreamingUW);
+        bool using_new_bs = programChecker.Check(PicoPrograms.BusinessStreaming);
 
         if (using_sa) return new LegacyConnector(Logger, PicoPrograms.StreamingAssistant);
-        else if (using_bs) return new LegacyConnector(Logger, PicoPrograms.BusinessStreaming);
+        else if (using_old_bs) return new LegacyConnector(Logger, PicoPrograms.BusinessStreamingUW);
+        else if (using_new_bs) return new LegacyConnector(Logger, PicoPrograms.BusinessStreaming);
         else if (using_pc)
         {
             try {

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConnectorFactory.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConnectorFactory.cs
@@ -11,12 +11,22 @@ public sealed class ConnectorFactory
     {
         bool using_sa = programChecker.Check(PicoPrograms.StreamingAssistant);
         bool using_pc = programChecker.Check(PicoPrograms.PicoConnect);
-        bool using_old_bs = programChecker.Check(PicoPrograms.BusinessStreamingUW);
+        bool using_old_bs = programChecker.Check(PicoPrograms.BusinessStreamingUw);
         bool using_new_bs = programChecker.Check(PicoPrograms.BusinessStreaming);
 
         if (using_sa) return new LegacyConnector(Logger, PicoPrograms.StreamingAssistant);
-        else if (using_old_bs) return new LegacyConnector(Logger, PicoPrograms.BusinessStreamingUW);
-        else if (using_new_bs) return new LegacyConnector(Logger, PicoPrograms.BusinessStreaming);
+        else if (using_old_bs) return new LegacyConnector(Logger, PicoPrograms.BusinessStreamingUw);
+        else if (using_new_bs)
+        {
+            try {
+                Logger.LogInformation("Got new Business Streaming; checking settings.json to choose what protocol to use...");
+                if (configChecker.GetTransferProtocolNumber(PicoPrograms.BusinessStreaming) == 2) return new LegacyConnector(Logger, PicoPrograms.BusinessStreaming); // using legacy protocol
+            } catch (Exception ex) {
+                Logger.LogWarning("Exception while trying to get the config protocol number: " + ex.ToString);
+            }
+            // TODO is the protocol the same as PicoConnect? can we use the same connector (once it's implemented)?
+            return new PicoConnectConnector(Logger); // couldn't get / using latest protocol
+        }
         else if (using_pc)
         {
             try {

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConnectorFactory.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ConnectorFactory.cs
@@ -11,11 +11,11 @@ public sealed class ConnectorFactory
     {
         bool using_sa = programChecker.Check(PicoPrograms.StreamingAssistant);
         bool using_pc = programChecker.Check(PicoPrograms.PicoConnect);
-        bool using_old_bs = programChecker.Check(PicoPrograms.BusinessStreamingUw);
+        bool using_old_bs = programChecker.Check(PicoPrograms.BusinessStreamingV1);
         bool using_new_bs = programChecker.Check(PicoPrograms.BusinessStreaming);
 
         if (using_sa) return new LegacyConnector(Logger, PicoPrograms.StreamingAssistant);
-        else if (using_old_bs) return new LegacyConnector(Logger, PicoPrograms.BusinessStreamingUw);
+        else if (using_old_bs) return new LegacyConnector(Logger, PicoPrograms.BusinessStreamingV1);
         else if (using_new_bs)
         {
             try {

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/LegacyConnector.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/LegacyConnector.cs
@@ -47,6 +47,7 @@ public sealed class LegacyConnector : IPicoConnector
                 this.processName = "Streaming Assistant";
                 break;
 
+            case PicoPrograms.BusinessStreamingUW:
             case PicoPrograms.BusinessStreaming:
                 this.processName = "Business Streaming";
                 break;
@@ -110,7 +111,8 @@ public sealed class LegacyConnector : IPicoConnector
         catch (SocketException ex) when (ex.ErrorCode is 10048)
         {
             if (retry >= 3) result = false;
-            else {
+            else
+            {
                 retry++;
                 // Magic
                 // Close the pico_et_ft_bt_bridge.exe process and reinitialize it.

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/LegacyConnector.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/LegacyConnector.cs
@@ -47,7 +47,7 @@ public sealed class LegacyConnector : IPicoConnector
                 this.processName = "Streaming Assistant";
                 break;
 
-            case PicoPrograms.BusinessStreamingUw:
+            case PicoPrograms.BusinessStreamingV1:
             case PicoPrograms.BusinessStreaming:
                 this.processName = "Business Streaming";
                 break;

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/LegacyConnector.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/LegacyConnector.cs
@@ -47,7 +47,7 @@ public sealed class LegacyConnector : IPicoConnector
                 this.processName = "Streaming Assistant";
                 break;
 
-            case PicoPrograms.BusinessStreamingUW:
+            case PicoPrograms.BusinessStreamingUw:
             case PicoPrograms.BusinessStreaming:
                 this.processName = "Business Streaming";
                 break;

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/PicoPrograms.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/PicoPrograms.cs
@@ -9,6 +9,7 @@ namespace Pico4SAFTExtTrackingModule.PicoConnectors;
 public enum PicoPrograms
 {
     StreamingAssistant,
+    BusinessStreamingUW,
     BusinessStreaming,
     PicoConnect
 }

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/PicoPrograms.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/PicoPrograms.cs
@@ -23,11 +23,11 @@ public enum PicoPrograms
 
     /**
      * Business Streaming (BS) is the successor of SA for business devices (PICO 4 enterprise).
-     * Due to a internal change since one BS version we keep this (BusinessStreamingUw)
-     * entry to refere to "old BS programs".
+     * Due to a internal change since one BS version we keep this (BusinessStreamingV1)
+     * entry to refere to "old BS 1.X programs".
      * Internally works similar to how SA did.
      */
-    BusinessStreamingUw,
+    BusinessStreamingV1,
 
     /**
      * Business Streaming (BS) is the successor of SA for business devices (PICO 4 enterprise).

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/PicoPrograms.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/PicoPrograms.cs
@@ -8,8 +8,30 @@ namespace Pico4SAFTExtTrackingModule.PicoConnectors;
 
 public enum PicoPrograms
 {
+    /**
+     * Streaming Assitant (SA) was the first program used to connect your PICO
+     * device to the computer.
+     */
     StreamingAssistant,
-    BusinessStreamingUW,
-    BusinessStreaming,
-    PicoConnect
+
+    /**
+     * PicoConnect is the successor of SA.
+     * Currently PicoConnect lacks of proper API to get facetracking data, so
+     * we force it to work like the old SA did and that way we can re-use the module.
+     */
+    PicoConnect,
+
+    /**
+     * Business Streaming (BS) is the successor of SA for business devices (PICO 4 enterprise).
+     * Due to a internal change since one BS version we keep this (BusinessStreamingUw)
+     * entry to refere to "old BS programs".
+     * Internally works similar to how SA did.
+     */
+    BusinessStreamingUw,
+
+    /**
+     * Business Streaming (BS) is the successor of SA for business devices (PICO 4 enterprise).
+     * Internally works similar to how PicoConnect do.
+     */
+    BusinessStreaming
 }

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/PicoPrograms.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/PicoPrograms.cs
@@ -15,7 +15,7 @@ public enum PicoPrograms
     StreamingAssistant,
 
     /**
-     * PicoConnect is the successor of SA.
+     * PICO Connect is the successor of SA.
      * Currently PicoConnect lacks of proper API to get facetracking data, so
      * we force it to work like the old SA did and that way we can re-use the module.
      */
@@ -31,7 +31,7 @@ public enum PicoPrograms
 
     /**
      * Business Streaming (BS) is the successor of SA for business devices (PICO 4 enterprise).
-     * Internally works similar to how PicoConnect do.
+     * Since 2.0, internally works similar to how PicoConnect do.
      */
     BusinessStreaming
 }

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ProgramChecker/ProcessRunningProgramChecker.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ProgramChecker/ProcessRunningProgramChecker.cs
@@ -23,8 +23,12 @@ public sealed class ProcessRunningProgramChecker : IProgramChecker
                 processName = "Streaming Assistant";
                 break;
 
-            case PicoPrograms.BusinessStreaming:
+            case PicoPrograms.BusinessStreamingUW:
                 processName = "Business StreamingUW";
+                break;
+
+            case PicoPrograms.BusinessStreaming:
+                processName = "Business Streaming";
                 break;
 
             case PicoPrograms.PicoConnect:

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ProgramChecker/ProcessRunningProgramChecker.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ProgramChecker/ProcessRunningProgramChecker.cs
@@ -23,7 +23,7 @@ public sealed class ProcessRunningProgramChecker : IProgramChecker
                 processName = "Streaming Assistant";
                 break;
 
-            case PicoPrograms.BusinessStreamingUw:
+            case PicoPrograms.BusinessStreamingV1:
                 processName = "Business StreamingUW";
                 break;
 

--- a/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ProgramChecker/ProcessRunningProgramChecker.cs
+++ b/PicoStreamingAssistantFTUDP/PicoStreamingAssistantFTUDP/PicoConnectors/ProgramChecker/ProcessRunningProgramChecker.cs
@@ -23,7 +23,7 @@ public sealed class ProcessRunningProgramChecker : IProgramChecker
                 processName = "Streaming Assistant";
                 break;
 
-            case PicoPrograms.BusinessStreamingUW:
+            case PicoPrograms.BusinessStreamingUw:
                 processName = "Business StreamingUW";
                 break;
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You'll find the module in `artifacts\Pico4SAFTExtTrackingModule.dll`
 
 ### Manual
 - Use [Visual Studio 2022](https://visualstudio.microsoft.com/es/vs/)
-- Clone [VRCFaceTracking 5.2.3.0](https://github.com/benaclejames/VRCFaceTracking/tree/5.2.3.0); this is done automatically if you run `git submodule update --init --recursive`
+- Clone [VRCFaceTracking 5.1.0.0](https://github.com/benaclejames/VRCFaceTracking/tree/5.1.0.0); this is done automatically if you run `git submodule update --init --recursive`
 - Compile VRCFaceTracking.Core
 - Finally, compile the PICO Module
 
@@ -67,5 +67,6 @@ You'll also find a summary in `PicoStreamingAssistantFTUDP\PicoStreamingAssistan
 ## Credits
 - [Ben](https://github.com/benaclejames/) for VRCFaceTracking!
 - [TofuLemon](https://github.com/ULemon/) with help testing, troubleshooting and providing crucial information that lead to the development of this module!
-- [rogermiranda1000](https://github.com/rogermiranda1000) for updating to the latest SA protocol.
+- [miranda1000](https://github.com/miranda1000) for updating to the latest SA protocol.
 - [lonelyicer](https://github.com/lonelyicer) for the recent contributions.
+- [FuviiPeshu](https://github.com/FuviiPeshu) for SA process detection fix.

--- a/metadata.json
+++ b/metadata.json
@@ -2,9 +2,9 @@
   "ModuleId": "4d885bd8-e97f-4e0d-be40-55c8503e0620",
   "AuthorName": "Mitchell Taylor",
   "DllFileName": "Pico4SAFTExtTrackingModule.dll",
-  "Downloads": 12048,
-  "DownloadUrl": "https://github.com/regzo2/PicoStreamingAssistantFTUDP/releases/download/1.5.1/Pico4ProModule.zip",
-  "LastUpdated": "2024-06-22T22:30:00Z",
+  "Downloads": 41964,
+  "DownloadUrl": "https://github.com/regzo2/PicoStreamingAssistantFTUDP/releases/download/1.6.0/Pico4ProModule.zip",
+  "LastUpdated": "2025-07-05T22:30:00Z",
   "ModuleDescription": "The module provides eye and face tracking compatibility with PICO Connect, Streaming Assistant and Business Streaming.",
   "ModuleName": "Pico4SAFTExtTrackingModule",
   "ModulePageUrl": "https://github.com/regzo2/PicoStreamingAssistantFTUDP/tree/vrcfacetracking-module",
@@ -12,5 +12,5 @@
   "Ratings": 164,
   "RatingSum": 712,
   "UsageInstructions": "Requires PICO Connect/Streaming Assistant (for PICO 4 PRO) or Business Streaming (for PICO 4 enterprise). This module will listen for any face tracking data coming from the Pico Streaming Assistant.",
-  "Version": "1.5.1"
+  "Version": "1.6.0"
 }


### PR DESCRIPTION
PICO once again broke the module by updating the streaming software for the business devices (Business Connect); now it looks like it works same as PICOConnect.

This PR should solve https://github.com/regzo2/PicoStreamingAssistantFTUDP/issues/32

Validation checks:
- [x] Unit tests
- [x] Old Business Streaming
- [ ] New Business Streaming
- [x] PICO Connect

StreamingAssistant not tested but should be fine, as code changes didn't affect that part of the module.