### PR TITLE
Fix crash by updating vrcft dll to latest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "VRCFaceTracking"]
 	path = VRCFaceTracking
 	url = https://github.com/benaclejames/VRCFaceTracking.git
-	branch = 5.1.0.0
+	branch = 5.2.3.0

--- a/metadata.json
+++ b/metadata.json
@@ -2,15 +2,15 @@
   "ModuleId": "4d885bd8-e97f-4e0d-be40-55c8503e0620",
   "AuthorName": "miranda1000, azmidi",
   "DllFileName": "Pico4SAFTExtTrackingModule.dll",
-  "Downloads": 41964,
+  "Downloads": 45032,
   "DownloadUrl": "https://github.com/regzo2/PicoStreamingAssistantFTUDP/releases/download/1.6.0/Pico4ProModule.zip",
   "LastUpdated": "2025-07-05T22:30:00Z",
   "ModuleDescription": "The module provides eye and face tracking compatibility with PICO Connect, Streaming Assistant and Business Streaming.",
   "ModuleName": "Pico4SAFTExtTrackingModule",
   "ModulePageUrl": "https://github.com/regzo2/PicoStreamingAssistantFTUDP/tree/vrcfacetracking-module",
-  "Rating": 4.410526315789474,
-  "Ratings": 570,
-  "RatingSum": 2514,
+  "Rating": 4.395387149917628,
+  "Ratings": 607,
+  "RatingSum": 2668,
   "UsageInstructions": "Requires PICO Connect/Streaming Assistant (for PICO 4 PRO) or Business Streaming (for PICO 4 enterprise). This module will listen for any face tracking data coming from the Pico Streaming Assistant.",
-  "Version": "1.6.0"
+  "Version": "1.6.1"
 }


### PR DESCRIPTION
Seems like using an old VRCFT .dll causes some users to crash https://github.com/regzo2/PicoStreamingAssistantFTUDP/issues/36

By updating the .dll (according to the beta feedback) we aim to solve this issues.